### PR TITLE
Update .replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-run = "pub update && dart bin/main.dart --ip=zero --port=8080"
+run = "dart pub update && dart bin/main.dart --ip=zero --port=8080"
 entrypoint = "bin/main.dart"
 
 [packager]
@@ -14,4 +14,4 @@ pattern = "**/*.dart"
 start = ["dart", "language-server"]
 
 [nix]
-channel = "stable-21_11"
+channel = "stable-22_11"


### PR DESCRIPTION
I think the Nix channel shows the year and the month, so this updates from Dart 2.14.3 to Dart 2.18